### PR TITLE
Add proof tracking for theorems

### DIFF
--- a/AxioMath.CliApp/Program.cs
+++ b/AxioMath.CliApp/Program.cs
@@ -56,4 +56,4 @@ var theory = new FormalTheory(system);
 
 // Mostrar teoremas deducidos
 foreach (var t in theory.Theorems)
-    Console.WriteLine("Teorema: " + t);
+    Console.WriteLine("Teorema: " + t.Formula);

--- a/AxioMath.Core/Formulas/FormalTheory.cs
+++ b/AxioMath.Core/Formulas/FormalTheory.cs
@@ -1,16 +1,17 @@
 
+using System.Linq;
 
 namespace AxioMath.Core.Formulas;
 public class FormalTheory
 {
     public FormalSystem System { get; }
-    public IEnumerable<Formula> Theorems => System.DeriveTheorems();
+    public IEnumerable<Theorem> Theorems => System.DeriveTheorems();
 
     public FormalTheory(FormalSystem system)
     {
         System = system;
     }
 
-    public bool Proves(Formula formula) => Theorems.Contains(formula);
+    public bool Proves(Formula formula) => Theorems.Any(t => t.Formula.Equals(formula));
 }
 

--- a/AxioMath.Core/Formulas/IDeductionRule.cs
+++ b/AxioMath.Core/Formulas/IDeductionRule.cs
@@ -4,6 +4,9 @@ namespace AxioMath.Core.Formulas;
 
 public interface IDeductionRule
 {
-    /// <summary>Applies the rule to a set of premises and produces conclusions if applicable.</summary>
-    IEnumerable<Formula> Apply(IEnumerable<Formula> premises, FormalLanguage language);
+    /// <summary>
+    /// Applies the rule to a set of premises and produces conclusions if applicable.
+    /// The returned tuple contains the derived formula and the premises used.
+    /// </summary>
+    IEnumerable<(Formula conclusion, IReadOnlyList<Formula> premises)> Apply(IEnumerable<Formula> premises, FormalLanguage language);
 }

--- a/AxioMath.Core/Formulas/Theorem.cs
+++ b/AxioMath.Core/Formulas/Theorem.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+
+namespace AxioMath.Core.Formulas;
+
+/// <summary>
+/// Represents a derived theorem along with the rule and premises used to derive it.
+/// </summary>
+public class Theorem
+{
+    public Formula Formula { get; }
+    public IDeductionRule? Rule { get; }
+    public IReadOnlyList<Theorem> Premises { get; }
+
+    public Theorem(Formula formula, IDeductionRule? rule = null, IReadOnlyList<Theorem>? premises = null)
+    {
+        Formula = formula;
+        Rule = rule;
+        Premises = premises ?? new List<Theorem>();
+    }
+}

--- a/AxioMath.Logic/DeductionRules/Propositional/ModusPonensRule.cs
+++ b/AxioMath.Logic/DeductionRules/Propositional/ModusPonensRule.cs
@@ -8,7 +8,7 @@ namespace AxioMath.Logic.DeductionRules.Propositional;
   
 public class ModusPonensRule : IDeductionRule
 {
-    public IEnumerable<Formula> Apply(IEnumerable<Formula> premises, FormalLanguage language)
+    public IEnumerable<(Formula conclusion, IReadOnlyList<Formula> premises)> Apply(IEnumerable<Formula> premises, FormalLanguage language)
     {
         var list = premises.ToList();
 
@@ -21,11 +21,10 @@ public class ModusPonensRule : IDeductionRule
                     AreEquivalent(imp.Left, p.Root))
                 {
                     var content = Serialize(imp.Right);
-                   
 
                     var result = TryCreateFormula(language, content, imp.Right);
                     if (result != null)
-                        yield return result;
+                        yield return (result, new List<Formula> { p, implication });
                 }
             }
         }

--- a/AxioMath.Logic/DeductionRules/Propositional/ModusTollens.cs
+++ b/AxioMath.Logic/DeductionRules/Propositional/ModusTollens.cs
@@ -6,7 +6,7 @@ namespace AxioMath.Logic.DeductionRules.Propositional;
 
 public class ModusTollensRule : IDeductionRule
 {
-    public IEnumerable<Formula> Apply(IEnumerable<Formula> premises, FormalLanguage language)
+    public IEnumerable<(Formula conclusion, IReadOnlyList<Formula> premises)> Apply(IEnumerable<Formula> premises, FormalLanguage language)
     {
         var list = premises.ToList();
 
@@ -25,7 +25,7 @@ public class ModusTollensRule : IDeductionRule
 
                         var result = TryCreateFormula(language, content, negatedP);
                         if (result != null)
-                            yield return result;
+                            yield return (result, new List<Formula> { implication, negatedQ });
                     }
                 }
             }

--- a/AxioMath.Tests/DeductionTests.cs
+++ b/AxioMath.Tests/DeductionTests.cs
@@ -2,6 +2,7 @@
 using AxioMath.Core.Formulas;
 using AxioMath.Core.Syntax;
 using AxioMath.Logic.DeductionRules.Propositional;
+using System.Linq;
 
 
 namespace AxioMath.Tests;
@@ -67,7 +68,12 @@ public class DeductionTests
         var theory = new FormalTheory(system);
 
         var q = lang.CreateFormula("q");
-        Assert.Contains(q, theory.Theorems);
+        var theorem = theory.Theorems.FirstOrDefault(t => t.Formula.Equals(q));
+        Assert.NotNull(theorem);
+        Assert.IsType<ModusPonensRule>(theorem!.Rule);
+        Assert.Equal(2, theorem.Premises.Count);
+        Assert.Contains(theorem.Premises, th => th.Formula.Equals(p));
+        Assert.Contains(theorem.Premises, th => th.Formula.Equals(imp));
     }
 
     [Fact]
@@ -79,7 +85,7 @@ public class DeductionTests
         var theory = new FormalTheory(system);
 
         var q = lang.CreateFormula("q");
-        Assert.DoesNotContain(q, theory.Theorems);
+        Assert.DoesNotContain(theory.Theorems, t => t.Formula.Equals(q));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- introduce new `Theorem` type that stores the rule and premises used
- update deduction rules to return premises along with conclusions
- extend `FormalSystem` and `FormalTheory` to work with `Theorem`
- adapt CLI and tests to use the new proof information

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873198427848324a4c1a0c9a1d92996